### PR TITLE
Add support for traits

### DIFF
--- a/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -8,9 +8,11 @@ use Phpactor\WorseReflection\Core\Inference\Variable;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\SourceCode as WorseSourceCode;
 use Phpactor\CodeBuilder\Domain\Updater;
+use Phpactor\CodeBuilder\Domain\Builder\ClassLikeBuilder;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionClassLike;
 
 class AddMissingProperties implements Transformer
 {
@@ -44,10 +46,7 @@ class AddMissingProperties implements Transformer
 
         /** @var ReflectionClass $class */
         foreach ($classes as $class) {
-
-            $classBuilder = $class->isTrait()
-                ? $sourceBuilder->trait($class->name()->short())
-                : $sourceBuilder->class($class->name()->short());
+            $classBuilder = $this->resolveClassBuilder($sourceBuilder, $class);
 
             foreach ($class->methods()->belongingTo($class->name()) as $method) {
                 $frame = $method->frame();
@@ -74,5 +73,16 @@ class AddMissingProperties implements Transformer
         );
 
         return SourceCode::fromString($code);
+    }
+
+    private function resolveClassBuilder(SourceCodeBuilder $sourceBuilder, ReflectionClassLike $class): ClassLikeBuilder
+    {
+        $name = $class->name()->short();
+
+        if ($class->isTrait()) {
+            return $sourceBuilder->trait($name);
+        }
+
+        return $sourceBuilder->class($name);
     }
 }

--- a/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -8,6 +8,9 @@ use Phpactor\WorseReflection\Core\Inference\Variable;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\SourceCode as WorseSourceCode;
 use Phpactor\CodeBuilder\Domain\Updater;
+use Phpactor\CodeBuilder\Domain\Builder\ClassLikeBuilder;
+use Phpactor\CodeBuilder\Domain\Builder\ClassBuilder;
+use Phpactor\CodeBuilder\Domain\Builder\TraitBuilder;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
@@ -74,7 +77,10 @@ class AddMissingProperties implements Transformer
         return SourceCode::fromString($code);
     }
 
-    private function resolveClassBuilder(SourceCodeBuilder $sourceBuilder, ReflectionClassLike $class)
+    /**
+     * @return TraitBuilder|ClassBuilder
+     */
+    private function resolveClassBuilder(SourceCodeBuilder $sourceBuilder, ReflectionClassLike $class): ClassLikeBuilder
     {
         $name = $class->name()->short();
 

--- a/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -44,7 +44,8 @@ class AddMissingProperties implements Transformer
 
         /** @var ReflectionClass $class */
         foreach ($classes as $class) {
-            $classBuilder = $sourceBuilder->class($class->name()->short());
+            $classOrTrait = $class->isTrait() ? 'trait' : 'class';
+            $classBuilder = $sourceBuilder->$classOrTrait($class->name()->short());
 
             foreach ($class->methods()->belongingTo($class->name()) as $method) {
                 $frame = $method->frame();

--- a/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -44,8 +44,10 @@ class AddMissingProperties implements Transformer
 
         /** @var ReflectionClass $class */
         foreach ($classes as $class) {
-            $classOrTrait = $class->isTrait() ? 'trait' : 'class';
-            $classBuilder = $sourceBuilder->$classOrTrait($class->name()->short());
+
+            $classBuilder = $class->isTrait()
+                ? $sourceBuilder->trait($class->name()->short())
+                : $sourceBuilder->class($class->name()->short());
 
             foreach ($class->methods()->belongingTo($class->name()) as $method) {
                 $frame = $method->frame();

--- a/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -8,7 +8,6 @@ use Phpactor\WorseReflection\Core\Inference\Variable;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\SourceCode as WorseSourceCode;
 use Phpactor\CodeBuilder\Domain\Updater;
-use Phpactor\CodeBuilder\Domain\Builder\ClassLikeBuilder;
 use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionClass;
@@ -75,7 +74,7 @@ class AddMissingProperties implements Transformer
         return SourceCode::fromString($code);
     }
 
-    private function resolveClassBuilder(SourceCodeBuilder $sourceBuilder, ReflectionClassLike $class): ClassLikeBuilder
+    private function resolveClassBuilder(SourceCodeBuilder $sourceBuilder, ReflectionClassLike $class)
     {
         $name = $class->name()->short();
 

--- a/tests/Adapter/WorseReflection/Transformer/AddMissingPropertiesTest.php
+++ b/tests/Adapter/WorseReflection/Transformer/AddMissingPropertiesTest.php
@@ -342,6 +342,36 @@ class Foobar
 EOT
 
             ],
+            'It adds missing trait properties within the Trait' => [
+                <<<'EOT'
+<?php
+
+trait Foobar
+{
+    public function hello()
+    {
+        $this->hello = 'goodbye';
+    }
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+trait Foobar
+{
+    /**
+     * @var string
+     */
+    private $hello;
+
+    public function hello()
+    {
+        $this->hello = 'goodbye';
+    }
+}
+EOT
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes phpactor/phpactor#726, but relies on phpactor/code-builder#9 to
get the underlying trait() method added with all its supporting code.