### PR TITLE
Add helper class for finding interesting offsets.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "phpactor/class-to-file": "~0.3"
     },
     "require-dev": {
-        "phpactor/worse-reflection": "~0.1",
+        "phpactor/worse-reflection": "~0.4",
         "phpactor/test-utils": "^1.0@dev",
         "phpstan/phpstan": "^0.10.3",
         "phpunit/phpunit": "^7.3",

--- a/lib/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinder.php
+++ b/lib/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Phpactor\CodeTransform\Adapter\WorseReflection\Helper;
+
+use Microsoft\PhpParser\Parser;
+use Phpactor\CodeTransform\Domain\Helper\InterestingOffsetFinder;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Core\Inference\Symbol;
+use Phpactor\WorseReflection\Core\Reflector\SourceCodeReflector;
+
+class WorseInterestingOffsetFinder implements InterestingOffsetFinder
+{
+    /**
+     * @var SourceCodeReflector
+     */
+    private $reflector;
+
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    public function __construct(SourceCodeReflector $reflector, Parser $parser = null)
+    {
+        $this->reflector = $reflector;
+        $this->parser = $parser ?: new Parser();
+    }
+
+    public function find(TextDocument $source, ByteOffset $offset): ByteOffset
+    {
+        $node = $this->parser->parseSourceFile($source->__toString())->getDescendantNodeAtPosition($offset->toInt());
+
+        do {
+            $reflectionOffset = $this->reflector->reflectOffset($source, $node->getStart());
+
+            $symbolType = $reflectionOffset->symbolContext()->symbol()->symbolType();
+
+            if ($symbolType != Symbol::UNKNOWN) {
+                return ByteOffset::fromInt($reflectionOffset->symbolContext()->symbol()->position()->start());
+            }
+
+            $node = $node->parent;
+        } while ($node);
+
+        return $offset;
+    }
+}

--- a/lib/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinder.php
+++ b/lib/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinder.php
@@ -36,8 +36,8 @@ class WorseInterestingOffsetFinder implements InterestingOffsetFinder
 
             $symbolType = $reflectionOffset->symbolContext()->symbol()->symbolType();
 
-            if ($symbolType != Symbol::UNKNOWN) {
-                return ByteOffset::fromInt($reflectionOffset->symbolContext()->symbol()->position()->start());
+            if ($symbolType !== Symbol::UNKNOWN) {
+                return ByteOffset::fromInt($node->getStart());
             }
 
             $node = $node->parent;

--- a/lib/Domain/Helper/InterestingOffsetFinder.php
+++ b/lib/Domain/Helper/InterestingOffsetFinder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phpactor\CodeTransform\Domain\Helper;
+
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocument;
+
+/**
+ * Return the nearest offset, relative to the given offset position, that is
+ * interesting.
+ *
+ * For example, if we are on:
+ *
+ * - whitespace within a class, return offset of class.
+ * - whitespace within a method, return offset of method
+ * - if the given offset is already interesting, then return that.
+ *
+ * This utility can be used to find an object of interest relative to a given
+ * offset, useful for context menus.
+ */
+interface InterestingOffsetFinder
+{
+    public function find(TextDocument $source, ByteOffset $offset): ByteOffset;
+}

--- a/tests/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinderTest.php
+++ b/tests/Adapter/WorseReflection/Helper/WorseInterestingOffsetFinderTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection\Helper;
+
+use Phpactor\CodeTransform\Adapter\WorseReflection\Helper\WorseInterestingOffsetFinder;
+use Phpactor\CodeTransform\Tests\Adapter\WorseReflection\WorseTestCase;
+use Phpactor\TestUtils\ExtractOffset;
+use Phpactor\TextDocument\ByteOffset;
+use Phpactor\TextDocument\TextDocumentBuilder;
+use Phpactor\WorseReflection\Core\Inference\Symbol;
+
+class WorseInterestingOffsetFinderTest extends WorseTestCase
+{
+
+    /**
+     * @dataProvider provideFindSomethingInterestingWhen
+     */
+    public function testFindSomethingIterestingWhen(string $source, string $expectedSymbolType)
+    {
+        [$source, $offset] = ExtractOffset::fromSource($source);
+        $reflector = $this->reflectorFor($source);
+        $document = TextDocumentBuilder::create($source)->build();
+        $offset = ByteOffset::fromInt($offset);
+
+        $newOffset = (new WorseInterestingOffsetFinder($reflector))->find($document, $offset);
+        $reflectionOffset = $reflector->reflectOffset($document, $newOffset);
+
+        $this->assertEquals($expectedSymbolType, $reflectionOffset->symbolContext()->symbol()->symbolType());
+    }
+
+    public function provideFindSomethingInterestingWhen()
+    {
+        yield 'offset in empty file' => [
+            <<<'EOT'
+<?php
+
+<>
+EOT
+            , Symbol::UNKNOWN,
+        ];
+
+        yield 'offset over target class' => [
+            <<<'EOT'
+<?php
+
+class F<>oobar
+{
+    }
+EOT
+            , Symbol::CLASS_,
+        ];
+
+        yield 'offset in whitespace in target class' => [
+            <<<'EOT'
+<?php
+
+class Foobar
+{
+<>
+}
+EOT
+            , Symbol::CLASS_,
+            ];
+
+        yield 'offset on method' => [
+            <<<'EOT'
+<?php
+
+class Foobar
+{
+    public function <>methodOne()
+    {
+    }
+}
+EOT
+            , Symbol::METHOD,
+        ];
+
+        yield 'offset in method' => [
+            <<<'EOT'
+<?php
+
+class Foobar
+{
+    public function methodOne()
+    {
+        <>
+    }
+}
+EOT
+            , Symbol::METHOD,
+        ];
+
+        yield 'offset on var' => [
+            <<<'EOT'
+<?php
+
+class Foobar
+{
+    public function methodOne()
+    {
+        $fo<>o;
+    }
+}
+EOT
+            , Symbol::VARIABLE,
+        ];
+
+        yield 'offset on expression' => [
+            <<<'EOT'
+<?php
+
+class Foobar
+{
+    public function methodOne()
+    {
+        $foo = $bar + 3 / 2 <>+ $foo;
+    }
+}
+EOT
+            , Symbol::VARIABLE,
+        ];
+    }
+}

--- a/tests/Adapter/WorseReflection/WorseTestCase.php
+++ b/tests/Adapter/WorseReflection/WorseTestCase.php
@@ -12,7 +12,7 @@ use Phpactor\WorseReflection\ReflectorBuilder;
 
 class WorseTestCase extends AdapterTestCase
 {
-    public function reflectorFor(string $source)
+    public function reflectorFor(string $source): Reflector
     {
         $builder = ReflectorBuilder::create();
 


### PR DESCRIPTION
This helper class is intended to facilitate finding things of interest
nearest to the cursor. The use case is related to context-menu
functionality - if the cursor is in a position which is not interesting
(e.g. whitespace) then search up the AST to find something interesting
(e.g. the class declaration).

The current implementation is quite dumb (but maybe clever enough) - it
traverses the ancestors of the node at the given offset until one is
found which is not an unknown symbol.

Other implementations might query all the refactorings to find out the
closest thing to which one could be applied, or a more strict rule-based
implementation which could return an offset of the first ancestor with
whitelisted node types.