### PR TITLE
Accessors are now uppercase by default if prefixed

### DIFF
--- a/lib/Adapter/WorseReflection/Refactor/WorseGenerateAccessor.php
+++ b/lib/Adapter/WorseReflection/Refactor/WorseGenerateAccessor.php
@@ -41,12 +41,12 @@ class WorseGenerateAccessor implements GenerateAccessor
         Reflector $reflector,
         Updater $updater,
         string $prefix = '',
-        bool $upperCaseFirst = false
+        bool $upperCaseFirst = null
     ) {
         $this->reflector = $reflector;
         $this->updater = $updater;
         $this->prefix = $prefix;
-        $this->upperCaseFirst = $upperCaseFirst;
+        $this->upperCaseFirst = ($prefix && $upperCaseFirst === null) || $upperCaseFirst;
     }
 
     public function generate(SourceCode $sourceCode, string $propertyName, int $offset): SourceCode

--- a/tests/Adapter/WorseReflection/Refactor/WorseGenerateAccessorTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseGenerateAccessorTest.php
@@ -16,7 +16,7 @@ class WorseGenerateAccessorTest extends WorseTestCase
         string $test,
         string $propertyName,
         string $prefix = '',
-        bool $upperCaseFirst = false
+        ?bool $upperCaseFirst = null
     ) {
         list($source, $expected, $offset) = $this->sourceExpectedAndOffset(
             __DIR__ . '/fixtures/' . $test
@@ -67,6 +67,17 @@ class WorseGenerateAccessorTest extends WorseTestCase
             'multiple-classes' => [
                 'generateAccessor6.test',
                 $propertyName,
+            ],
+            'prefix but ucfirst by default' => [
+                'generateAccessor7.test',
+                $propertyName,
+                'get',
+            ],
+            'prefix but ucfirst to false' => [
+                'generateAccessor8.test',
+                $propertyName,
+                'get',
+                false,
             ],
         ];
     }

--- a/tests/Adapter/WorseReflection/Refactor/fixtures/generateAccessor7.test
+++ b/tests/Adapter/WorseReflection/Refactor/fixtures/generateAccessor7.test
@@ -1,0 +1,19 @@
+// File: source
+<?php
+
+class generateMethod
+{
+    pr<>ivate $method;
+}
+// File: expected
+<?php
+
+class generateMethod
+{
+    private $method;
+
+    public function getMethod()
+    {
+        return $this->method;
+    }
+}

--- a/tests/Adapter/WorseReflection/Refactor/fixtures/generateAccessor8.test
+++ b/tests/Adapter/WorseReflection/Refactor/fixtures/generateAccessor8.test
@@ -1,0 +1,19 @@
+// File: source
+<?php
+
+class generateMethod
+{
+    pr<>ivate $method;
+}
+// File: expected
+<?php
+
+class generateMethod
+{
+    private $method;
+
+    public function getmethod()
+    {
+        return $this->method;
+    }
+}


### PR DESCRIPTION
We keep the ability to have a prefix and a lowercase if needed, but by
default, having a prefix activates the uppercase.

We now have `$upperCaseFirst` set to `null` by default to distinguish between an explicit `false` and a default value.
We don't simply set it to `true` by default, because it would give the following result without prefix: `public function Property()`