### PR TITLE
Fix import from phpdoc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "phpactor/code-builder": "^0.4",
+        "phpactor/code-builder": "^0.4.1",
         "webmozart/path-util": "~2.3",
         "phpactor/class-to-file": "~0.3",
         "phpactor/name-specification": "^0.1",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Applies introspective transformations on source code",
     "license": "MIT",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Daniel Leech",

--- a/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -9,7 +9,6 @@ use Phpactor\CodeTransform\Domain\Refactor\ImportName;
 use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Domain\SourceCode;
 use Microsoft\PhpParser\Node\QualifiedName;
-use Phpactor\CodeTransform\Domain\Exception\TransformException;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyImportedException;
 use Phpactor\CodeTransform\Domain\ClassName;
 use Phpactor\CodeBuilder\Domain\Updater;
@@ -64,21 +63,6 @@ class TolerantImportName implements ImportName
         return $edits;
     }
 
-    private function nameFromQualifiedName(QualifiedName $node): string
-    {
-        $parts = $node->getNameParts();
-
-        if (count($parts) === 0) {
-            throw new TransformException(sprintf(
-                'Name must have at least one part (this shouldn\'t happen'
-            ));
-        }
-
-        $name = array_shift($parts);
-
-        return $name->getText($node->getFileContents());
-    }
-
     private function assertNotAlreadyImported(Node $node, NameImport $nameImport): void
     {
         $currentClass = $this->currentClass($node);
@@ -117,7 +101,6 @@ class TolerantImportName implements ImportName
 
         return false;
     }
-
 
     private function addImport(SourceCode $source, NameImport $nameImport): TextEdits
     {

--- a/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -55,7 +55,7 @@ class TolerantImportName implements ImportName
 
         $this->assertNotAlreadyImported($node, $nameImport);
 
-        $edits = $this->addImport($source, $node, $nameImport);
+        $edits = $this->addImport($source, $nameImport);
 
         if ($nameImport->alias() !== null) {
             $edits = $this->updateReferences($node, $nameImport, $edits);
@@ -119,7 +119,7 @@ class TolerantImportName implements ImportName
     }
 
 
-    private function addImport(SourceCode $source, Node $node, NameImport $nameImport): TextEdits
+    private function addImport(SourceCode $source, NameImport $nameImport): TextEdits
     {
         $builder = SourceCodeBuilder::create();
 

--- a/tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
@@ -27,49 +27,49 @@ class TolerantImportNameTest extends TolerantTestCase
 
     public function provideImportClass()
     {
-        /* yield 'with existing class imports' => [ */
-        /*     'importClass1.test', */
-        /*     'Barfoo\Foobar', */
-        /* ]; */
+        yield 'with existing class imports' => [
+            'importClass1.test',
+            'Barfoo\Foobar',
+        ];
 
-        /* yield 'with namespace' => [ */
-        /*     'importClass2.test', */
-        /*     'Barfoo\Foobar', */
-        /* ]; */
+        yield 'with namespace' => [
+            'importClass2.test',
+            'Barfoo\Foobar',
+        ];
 
-        /* yield 'with no namespace declaration or use statements' => [ */
-        /*     'importClass3.test', */
-        /*     'Barfoo\Foobar', */
-        /* ]; */
+        yield 'with no namespace declaration or use statements' => [
+            'importClass3.test',
+            'Barfoo\Foobar',
+        ];
 
-        /* yield 'with alias' => [ */
-        /*     'importClass4.test', */
-        /*     'Barfoo\Foobar', */
-        /*     'Barfoo', */
-        /* ]; */
+        yield 'with alias' => [
+            'importClass4.test',
+            'Barfoo\Foobar',
+            'Barfoo',
+        ];
 
-        /* yield 'with static alias' => [ */
-        /*     'importClass5.test', */
-        /*     'Barfoo\Foobar', */
-        /*     'Barfoo', */
-        /* ]; */
+        yield 'with static alias' => [
+            'importClass5.test',
+            'Barfoo\Foobar',
+            'Barfoo',
+        ];
 
-        /* yield 'with multiple aliases' => [ */
-        /*     'importClass6.test', */
-        /*     'Barfoo\Foobar', */
-        /*     'Barfoo', */
-        /* ]; */
+        yield 'with multiple aliases' => [
+            'importClass6.test',
+            'Barfoo\Foobar',
+            'Barfoo',
+        ];
 
-        /* yield 'with alias and existing name' => [ */
-        /*     'importClass7.test', */
-        /*     'Barfoo\Foobar', */
-        /*     'Barfoo', */
-        /* ]; */
+        yield 'with alias and existing name' => [
+            'importClass7.test',
+            'Barfoo\Foobar',
+            'Barfoo',
+        ];
 
-        /* yield 'with class in root namespace' => [ */
-        /*     'importClass8.test', */
-        /*     'Foobar', */
-        /* ]; */
+        yield 'with class in root namespace' => [
+            'importClass8.test',
+            'Foobar',
+        ];
 
         yield 'from phpdoc' => [
             'importClass9.test',

--- a/tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantImportNameTest.php
@@ -27,48 +27,58 @@ class TolerantImportNameTest extends TolerantTestCase
 
     public function provideImportClass()
     {
-        yield 'with existing class imports' => [
-            'importClass1.test',
+        /* yield 'with existing class imports' => [ */
+        /*     'importClass1.test', */
+        /*     'Barfoo\Foobar', */
+        /* ]; */
+
+        /* yield 'with namespace' => [ */
+        /*     'importClass2.test', */
+        /*     'Barfoo\Foobar', */
+        /* ]; */
+
+        /* yield 'with no namespace declaration or use statements' => [ */
+        /*     'importClass3.test', */
+        /*     'Barfoo\Foobar', */
+        /* ]; */
+
+        /* yield 'with alias' => [ */
+        /*     'importClass4.test', */
+        /*     'Barfoo\Foobar', */
+        /*     'Barfoo', */
+        /* ]; */
+
+        /* yield 'with static alias' => [ */
+        /*     'importClass5.test', */
+        /*     'Barfoo\Foobar', */
+        /*     'Barfoo', */
+        /* ]; */
+
+        /* yield 'with multiple aliases' => [ */
+        /*     'importClass6.test', */
+        /*     'Barfoo\Foobar', */
+        /*     'Barfoo', */
+        /* ]; */
+
+        /* yield 'with alias and existing name' => [ */
+        /*     'importClass7.test', */
+        /*     'Barfoo\Foobar', */
+        /*     'Barfoo', */
+        /* ]; */
+
+        /* yield 'with class in root namespace' => [ */
+        /*     'importClass8.test', */
+        /*     'Foobar', */
+        /* ]; */
+
+        yield 'from phpdoc' => [
+            'importClass9.test',
             'Barfoo\Foobar',
         ];
 
-        yield 'with namespace' => [
-            'importClass2.test',
+        yield 'from phpdoc (resolved in a SourceFileNode)' => [
+            'importClass10.test',
             'Barfoo\Foobar',
-        ];
-
-        yield 'with no namespace declaration or use statements' => [
-            'importClass3.test',
-            'Barfoo\Foobar',
-        ];
-
-        yield 'with alias' => [
-            'importClass4.test',
-            'Barfoo\Foobar',
-            'Barfoo',
-        ];
-
-        yield 'with static alias' => [
-            'importClass5.test',
-            'Barfoo\Foobar',
-            'Barfoo',
-        ];
-
-        yield 'with multiple aliases' => [
-            'importClass6.test',
-            'Barfoo\Foobar',
-            'Barfoo',
-        ];
-
-        yield 'with alias and existing name' => [
-            'importClass7.test',
-            'Barfoo\Foobar',
-            'Barfoo',
-        ];
-
-        yield 'with class in root namespace' => [
-            'importClass8.test',
-            'Foobar',
         ];
     }
 

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/importClass10.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/importClass10.test
@@ -1,0 +1,19 @@
+// File: source
+<?php
+
+use DateTime;
+use Foo;
+use Bar;
+
+/** @var Foo<>Bar $foobar */
+$foobar = $container->get('fooboar');
+// File: expected
+<?php
+
+use Barfoo\Foobar;
+use DateTime;
+use Foo;
+use Bar;
+
+/** @var FooBar $foobar */
+$foobar = $container->get('fooboar');

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/importClass9.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/importClass9.test
@@ -1,0 +1,29 @@
+// File: source
+<?php
+
+use DateTime;
+use Foo;
+use Bar;
+
+class Test
+{
+    /**
+     * @var Foo<>Bar $foobar
+     */
+    private $foobar;
+}
+// File: expected
+<?php
+
+use Barfoo\Foobar;
+use DateTime;
+use Foo;
+use Bar;
+
+class Test
+{
+    /**
+     * @var FooBar $foobar
+     */
+    private $foobar;
+}


### PR DESCRIPTION
Fix https://github.com/phpactor/phpactor/issues/1106

The problem was a check added to accept only node implementing the `NamespacedNameInterface`.
But when the cursor is, for example, inside a phpdoc block (which are not recognized as node by the parser) we had issues.

I added two test case:
One more "usual" with some phpdoc on a property declaration.

Another one to deal with the case where the node is resolved to be a `SourceFileNode`. Because the parser throw an exception when trying to access the namespace definition from a `SourceFileNode` (@dantleech you had open an issue about that on their github page already).
So in this case we look for the last node just before the cursor position so that we can work with a proper import table.

This fix will not pass the unit tests until https://github.com/phpactor/code-builder/pull/23 is merged, this is because one of the two tests I added show an issue with the current implementation of the code builder.