### PR TITLE
Fix unresolved traits

### DIFF
--- a/lib/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinder.php
+++ b/lib/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinder.php
@@ -19,6 +19,7 @@ use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Domain\Helper\UnresolvableClassNameFinder;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Patch\TolerantQualifiedNameResolver;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Reflector;
 
@@ -72,7 +73,8 @@ class WorseUnresolvableClassNameFinder implements UnresolvableClassNameFinder
 
     private function appendUnresolvedName(QualifiedName $name, array $unresolvedNames): array
     {
-        $resolvedName = (string)$name->getResolvedName();
+        // Tolerant parser does not resolve names for constructs that define symbol names or aliases
+        $resolvedName = TolerantQualifiedNameResolver::getResolvedName($name);
 
         // Parser returns "NULL" for unqualified namespaced function / constant
         // names, but will return the FQN for references...

--- a/tests/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinderTest.php
+++ b/tests/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinderTest.php
@@ -149,7 +149,7 @@ EOT
             ]
         ];
 
-        yield 'trait' => [
+        yield 'unresolvable trait' => [
             <<<'EOT'
 // File: test.php
 <?php 
@@ -165,6 +165,100 @@ EOT
                     ByteOffset::fromInt(28)
                 ),
             ]
+        ];
+
+        yield 'resolvable fully qualified trait' => [
+            <<<'EOT'
+// File: test.php
+<?php 
+
+namespace Test;
+
+class Bar {
+    use \App\Sugar;
+}
+// File: Sugar.php
+<?php 
+
+namespace App;
+
+trait Sugar {
+}
+EOT
+,
+            []
+        ];
+
+        yield 'resolvable partially qualified trait' => [
+            <<<'EOT'
+// File: test.php
+<?php 
+
+namespace Test;
+
+use App;
+
+class Bar {
+    use App\Sugar;
+}
+// File: Sugar.php
+<?php 
+
+namespace App;
+
+trait Sugar {
+}
+EOT
+,
+            []
+        ];
+
+        yield 'resolvable unqualified trait' => [
+            <<<'EOT'
+// File: test.php
+<?php 
+
+namespace Test;
+
+use App\Sugar;
+
+class Bar {
+    use Sugar;
+}
+// File: Sugar.php
+<?php 
+
+namespace App;
+
+trait Sugar {
+}
+EOT
+,
+            []
+        ];
+
+        yield 'resolvable alias trait' => [
+            <<<'EOT'
+// File: test.php
+<?php 
+
+namespace Test;
+
+use App\Sugar as SweetSugar;
+
+class Bar {
+    use SweetSugar;
+}
+// File: Sugar.php
+<?php 
+
+namespace App;
+
+trait Sugar {
+}
+EOT
+,
+            []
         ];
 
         yield 'external resolvable class' => [


### PR DESCRIPTION
The `ImportNameProvider` does not recognized imported traits.
The problem come from the `WorseUnresolvableClassNameFinder` which uses the Tolerant parser to resolve the names.
But the Tolerant parser does not resolve names for the traits.
This is a problem you already had I guess since you created a `TolerantQualifiedNameResolver` which does not ignore traits.