### PR TITLE
Fix invalid missing property diagnostic

### DIFF
--- a/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
+++ b/lib/Adapter/WorseReflection/Transformer/AddMissingProperties.php
@@ -111,6 +111,16 @@ class AddMissingProperties implements Transformer
 
                 foreach ($frame->properties() as $assignedProperty) {
                     assert($assignedProperty instanceof Variable);
+
+                    $assignedPropertyClass = $assignedProperty->symbolContext()->containerType();
+
+                    if (
+                        $assignedPropertyClass
+                        && $class->name() != $assignedPropertyClass->className()
+                    ) {
+                        continue;
+                    }
+
                     if ($class->properties()->has($assignedProperty->name())) {
                         continue;
                     }

--- a/tests/Adapter/WorseReflection/Transformer/AddMissingPropertiesTest.php
+++ b/tests/Adapter/WorseReflection/Transformer/AddMissingPropertiesTest.php
@@ -406,5 +406,26 @@ EOT
             '<?php class A { private $bar; public function bar() { $this->bar = "foo"; } }',
             0
         ];
+
+        yield 'ignores property from another class' => [
+            <<<'EOT'
+<?php
+
+namespace Test;
+
+use Test\Yet\AnotherClass;
+
+class Foo
+{
+    public function test(AnotherClass $anotherClass): void
+    {
+        assert($anotherClass->doesNotMatter instanceof SecretImplementation);
+
+        $anotherClass->doesNotMatter = 'test';
+    }
+}
+EOT
+            , 0
+        ];
     }
 }

--- a/tests/Adapter/WorseReflection/WorseTestCase.php
+++ b/tests/Adapter/WorseReflection/WorseTestCase.php
@@ -3,6 +3,7 @@
 namespace Phpactor\CodeTransform\Tests\Adapter\WorseReflection;
 
 use Phpactor\CodeTransform\Tests\Adapter\AdapterTestCase;
+use Phpactor\WorseReflection\Core\Inference\FrameBuilder\AssertFrameWalker;
 use Phpactor\WorseReflection\Core\SourceCode;
 use Phpactor\WorseReflection\Core\SourceCodeLocator\TemporarySourceLocator;
 use Phpactor\WorseReflection\Reflector;
@@ -25,6 +26,8 @@ class WorseTestCase extends AdapterTestCase
         if ($source) {
             $builder->addSource($source);
         }
+
+        $builder->addFrameWalker(new AssertFrameWalker());
 
         return $builder->build();
     }


### PR DESCRIPTION
The PR https://github.com/phpactor/worse-reflection/pull/73 fixed an inference type issue but generate some false positive diagnostics.
This fixes those.