### PR TITLE
Change GenerateMethod return value to TextEdits

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,6 +9,7 @@ $finder = PhpCsFixer\Finder::create()
 ;
 
 return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
         'no_unused_imports' => true,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpactor/class-to-file": "~0.4.0",
         "phpactor/code-builder": "^0.4.1",
         "phpactor/name-specification": "^0.1",
-        "phpactor/text-document": "^1.2.3",
+        "phpactor/text-document": "^1.2.4",
         "phpactor/worse-reflection": "^0.4.4",
         "webmozart/path-util": "~2.3"
     },

--- a/lib/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -59,10 +59,6 @@ class WorseGenerateMethod implements GenerateMethod
         $sourceCode = $this->resolveSourceCode($sourceCode, $methodCall, $visibility);
 
         return $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode));
-        // return SourceCode::fromStringAndPath(
-        //     (string) $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode))->apply($sourceCode),
-        //     $sourceCode->path()
-        // );
     }
 
     private function resolveSourceCode(SourceCode $sourceCode, ReflectionMethodCall $methodCall, string $visibility): SourceCode

--- a/lib/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -7,6 +7,7 @@ use Phpactor\CodeBuilder\Domain\Prototype\SourceCode as PhpactorSourceCode;
 use Phpactor\CodeBuilder\Domain\Prototype\Visibility;
 use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateMethod;
+use Phpactor\TextDocument\TextEdits;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionArgument;
 use Phpactor\CodeTransform\Domain\SourceCode;
@@ -46,7 +47,7 @@ class WorseGenerateMethod implements GenerateMethod
         $this->factory = $factory;
     }
 
-    public function generateMethod(SourceCode $sourceCode, int $offset, ?string $methodName = null): SourceCode
+    public function generateMethod(SourceCode $sourceCode, int $offset, ?string $methodName = null): TextEdits
     {
         $contextType = $this->contextType($sourceCode, $offset);
         $worseSourceCode = WorseSourceCode::fromPathAndString((string) $sourceCode->path(), (string) $sourceCode);
@@ -57,10 +58,11 @@ class WorseGenerateMethod implements GenerateMethod
         $prototype = $this->addMethodCallToBuilder($methodCall, $visibility, $methodCall->isStatic(), $methodName);
         $sourceCode = $this->resolveSourceCode($sourceCode, $methodCall, $visibility);
 
-        return SourceCode::fromStringAndPath(
-            (string) $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode))->apply($sourceCode),
-            $sourceCode->path()
-        );
+        return $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode));
+        // return SourceCode::fromStringAndPath(
+        //     (string) $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode))->apply($sourceCode),
+        //     $sourceCode->path()
+        // );
     }
 
     private function resolveSourceCode(SourceCode $sourceCode, ReflectionMethodCall $methodCall, string $visibility): SourceCode

--- a/lib/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
+++ b/lib/Adapter/WorseReflection/Refactor/WorseGenerateMethod.php
@@ -7,7 +7,8 @@ use Phpactor\CodeBuilder\Domain\Prototype\SourceCode as PhpactorSourceCode;
 use Phpactor\CodeBuilder\Domain\Prototype\Visibility;
 use Phpactor\CodeBuilder\Domain\Updater;
 use Phpactor\CodeTransform\Domain\Refactor\GenerateMethod;
-use Phpactor\TextDocument\TextEdits;
+use Phpactor\TextDocument\TextDocumentEdits;
+use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Reflector;
 use Phpactor\WorseReflection\Core\Reflection\ReflectionArgument;
 use Phpactor\CodeTransform\Domain\SourceCode;
@@ -47,18 +48,21 @@ class WorseGenerateMethod implements GenerateMethod
         $this->factory = $factory;
     }
 
-    public function generateMethod(SourceCode $sourceCode, int $offset, ?string $methodName = null): TextEdits
+    public function generateMethod(SourceCode $sourceCode, int $offset, ?string $methodName = null): TextDocumentEdits
     {
         $contextType = $this->contextType($sourceCode, $offset);
         $worseSourceCode = WorseSourceCode::fromPathAndString((string) $sourceCode->path(), (string) $sourceCode);
         $methodCall = $this->reflector->reflectMethodCall($worseSourceCode, $offset);
+        
         $this->validate($methodCall);
         $visibility = $this->determineVisibility($contextType, $methodCall->class());
 
         $prototype = $this->addMethodCallToBuilder($methodCall, $visibility, $methodCall->isStatic(), $methodName);
         $sourceCode = $this->resolveSourceCode($sourceCode, $methodCall, $visibility);
 
-        return $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode));
+        $textEdits = $this->updater->textEditsFor($prototype, Code::fromString((string) $sourceCode));
+        
+        return new TextDocumentEdits(TextDocumentUri::fromString($sourceCode->path()), $textEdits);
     }
 
     private function resolveSourceCode(SourceCode $sourceCode, ReflectionMethodCall $methodCall, string $visibility): SourceCode

--- a/lib/Domain/Refactor/GenerateMethod.php
+++ b/lib/Domain/Refactor/GenerateMethod.php
@@ -3,9 +3,9 @@
 namespace Phpactor\CodeTransform\Domain\Refactor;
 
 use Phpactor\CodeTransform\Domain\SourceCode;
-use Phpactor\TextDocument\TextEdits;
+use Phpactor\TextDocument\TextDocumentEdits;
 
 interface GenerateMethod
 {
-    public function generateMethod(SourceCode $sourceCode, int $offset): TextEdits;
+    public function generateMethod(SourceCode $sourceCode, int $offset): TextDocumentEdits;
 }

--- a/lib/Domain/Refactor/GenerateMethod.php
+++ b/lib/Domain/Refactor/GenerateMethod.php
@@ -3,8 +3,9 @@
 namespace Phpactor\CodeTransform\Domain\Refactor;
 
 use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\TextDocument\TextEdits;
 
 interface GenerateMethod
 {
-    public function generateMethod(SourceCode $sourceCode, int $offset): SourceCode;
+    public function generateMethod(SourceCode $sourceCode, int $offset): TextEdits;
 }

--- a/tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -13,7 +13,7 @@ class WorseGenerateMethodTest extends WorseTestCase
     /**
      * @dataProvider provideExtractMethod
      */
-    public function testGenerateMethod(string $test, $name = null): void
+    public function testGenerateMethod(string $test, ?string $name = null): void
     {
         list($source, $expected, $offset) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
@@ -22,7 +22,7 @@ class WorseGenerateMethodTest extends WorseTestCase
         $this->assertEquals(trim($expected), trim($transformed));
     }
 
-    public function provideExtractMethod()
+    public function provideExtractMethod(): array
     {
         return [
             'string' => [
@@ -89,11 +89,17 @@ class WorseGenerateMethodTest extends WorseTestCase
         $this->generateMethod($source, 152, 'test_name');
     }
 
-    private function generateMethod(string $source, int $start, $name)
+    private function generateMethod(string $source, int $start, ?string $name): string
     {
         $reflector = $this->reflectorForWorkspace($source);
         $factory = new WorseBuilderFactory($reflector);
         $generateMethod = new WorseGenerateMethod($reflector, $factory, $this->updater());
-        return $generateMethod->generateMethod(SourceCode::fromString($source), $start, $name);
+        $sourceCode = SourceCode::fromString($source);
+        $edits = $generateMethod->generateMethod($sourceCode, $start, $name);
+        $transformed = SourceCode::fromStringAndPath(
+            (string) $edits->apply($sourceCode),
+            $sourceCode->path()
+        );
+        return $transformed;
     }
 }

--- a/tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -92,12 +92,10 @@ class WorseGenerateMethodTest extends WorseTestCase
     private function generateMethod(string $source, int $start, ?string $name): string
     {
         $reflector = $this->reflectorForWorkspace($source);
-        $factory = new WorseBuilderFactory($reflector);
-        $generateMethod = new WorseGenerateMethod($reflector, $factory, $this->updater());
+        $generateMethod = new WorseGenerateMethod($reflector, new WorseBuilderFactory($reflector), $this->updater());
         $sourceCode = SourceCode::fromString($source);
-        $edits = $generateMethod->generateMethod($sourceCode, $start, $name);
         $transformed = SourceCode::fromStringAndPath(
-            (string) $edits->apply($sourceCode),
+            (string) $generateMethod->generateMethod($sourceCode, $start, $name)->apply($sourceCode),
             $sourceCode->path()
         );
         return $transformed;

--- a/tests/Adapter/WorseReflection/WorseTestCase.php
+++ b/tests/Adapter/WorseReflection/WorseTestCase.php
@@ -13,13 +13,13 @@ use Phpactor\WorseReflection\ReflectorBuilder;
 
 class WorseTestCase extends AdapterTestCase
 {
-    public function reflectorForWorkspace(?string $source = null): Reflector
+    public function reflectorForWorkspace($source = null): Reflector
     {
         $builder = ReflectorBuilder::create();
 
         foreach ((array)glob($this->workspace()->path('/*.php')) as $file) {
             $locator = new TemporarySourceLocator(ReflectorBuilder::create()->build(), true);
-            $locator->pushSourceCode(SourceCode::fromString(file_get_contents($file)));
+            $locator->pushSourceCode(SourceCode::fromPathAndString($file, file_get_contents($file)));
             $builder->addLocator($locator);
         }
 


### PR DESCRIPTION
Changed the refactoring's return value. Once we agree on this, I will change the rest in order to prepare them to be used in LSP. Haven't done the **phpactor** change as well (`TextEdits->apply(SourceCode)`).

Also, for some reason I had to add `allowRisky` for the CS fixer, because it would run otherwise.