### PR TITLE
Add ImportName::importNameOnly

### DIFF
--- a/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -60,6 +60,16 @@ class TolerantImportName implements ImportName
         return $edits;
     }
 
+    public function importNameOnly(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits
+    {
+        $sourceNode = $this->parser->parseSourceFile($source);
+        $node = $this->getLastNodeAtPosition($sourceNode, $offset);
+
+        $this->assertNotAlreadyImported($node, $nameImport);
+
+        return $this->addImport($source, $nameImport);
+    }
+
     private function assertNotAlreadyImported(Node $node, NameImport $nameImport): void
     {
         $currentClass = $this->currentClass($node);

--- a/lib/Domain/Refactor/ImportName.php
+++ b/lib/Domain/Refactor/ImportName.php
@@ -10,4 +10,13 @@ use Phpactor\TextDocument\TextEdits;
 interface ImportName
 {
     public function importName(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits;
+
+    /**
+     * Implementers must provide text edits for the import only without updating references.
+     *
+     * @param SourceCode $source
+     * @param NameImport $nameImport
+     * @return TextEdits
+     */
+    public function importNameOnly(SourceCode $source, ByteOffset $offset, NameImport $nameImport): TextEdits;
 }

--- a/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpactor\CodeTransform\Tests\Adapter\TolerantParser\Refactor;
+
+use Generator;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\ClassIsCurrentClassException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyImportedException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyInNamespaceException;
+use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameImport;
+use Phpactor\CodeTransform\Tests\Adapter\TolerantParser\TolerantTestCase;
+use Phpactor\TextDocument\TextEdits;
+
+abstract class AbstractTolerantImportNameTest extends TolerantTestCase
+{
+    /**
+     * @dataProvider provideImportClass
+     */
+    public function testImportClass(string $test, string $name, string $alias = null): void
+    {
+        list($expected, $transformed) = $this->importNameFromTestFile('class', $test, $name, $alias);
+
+        $this->assertEquals(trim($expected), trim($transformed));
+    }
+
+    abstract public function provideImportClass(): Generator;
+
+    public function testThrowsExceptionIfClassAlreadyImported(): void
+    {
+        $this->expectException(NameAlreadyImportedException::class);
+        $this->expectExceptionMessage('Class "DateTime" is already imported');
+        $this->importNameFromTestFile('class', 'importClass1.test', 'DateTime');
+    }
+
+    public function testThrowsExceptionIfImportedClassIsTheCurrentClass1(): void
+    {
+        $this->expectException(ClassIsCurrentClassException::class);
+        $this->expectExceptionMessage('Class "Foobar" is the current class');
+        $this->importName('<?php class Foobar {}', 14, NameImport::forClass('Foobar'));
+    }
+
+    public function testThrowsExceptionIfAliasAlreadyUsed(): void
+    {
+        $this->expectException(AliasAlreadyUsedException::class);
+        $this->expectExceptionMessage('Class alias "DateTime" is already used');
+        $this->importNameFromTestFile('class', 'importClass1.test', 'Foobar', 'DateTime');
+    }
+
+    public function testThrowsExceptionIfImportedClassHasSameNameAsCurrentClassName(): void
+    {
+        $this->expectException(NameAlreadyImportedException::class);
+        $this->importName(
+            '<?php namespace Barfoo; class Foobar extends Foobar',
+            47,
+            NameImport::forClass('BazBar\Foobar')
+        );
+    }
+
+    public function testThrowsExceptionIfImportedClassHasSameNameAsCurrentInterfaceName(): void
+    {
+        $this->expectException(NameAlreadyImportedException::class);
+        $this->importName(
+            '<?php namespace Barfoo; interface Foobar extends Foobar',
+            50,
+            NameImport::forClass('BazBar\Foobar')
+        );
+    }
+
+    public function testThrowsExceptionIfImportedClassInSameNamespace(): void
+    {
+        $this->expectException(NameAlreadyInNamespaceException::class);
+        $this->expectExceptionMessage('Class "Barfoo" is in the same namespace as current class');
+        $source = <<<'EOT'
+            <?php
+
+            namespace Barfoo;
+            class Foobar {
+                public function use(Barfoo $barfoo) {}
+                }
+            }
+            EOT;
+        $this->importName($source, 64, NameImport::forClass('Barfoo\Barfoo'));
+    }
+
+    /**
+     * @dataProvider provideImportFunction
+     */
+    public function testImportFunction(string $test, string $name, string $alias = null): void
+    {
+        list($expected, $transformed) = $this->importNameFromTestFile('function', $test, $name, $alias);
+
+        $this->assertEquals(trim($expected), trim($transformed));
+    }
+
+    abstract public function provideImportFunction(): Generator;
+
+    abstract protected function importName($source, int $offset, NameImport $nameImport): TextEdits;
+
+    private function importNameFromTestFile(string $type, string $test, string $name, string $alias = null)
+    {
+        list($source, $expected, $offset) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        $edits = TextEdits::none();
+
+        if ($type === 'class') {
+            $edits = $this->importName($source, $offset, NameImport::forClass($name, $alias));
+        }
+
+        if ($type === 'function') {
+            $edits = $this->importName($source, $offset, NameImport::forFunction($name, $alias));
+        }
+
+        return [$expected, $edits->apply($source)];
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/TolerantImportNameOnlyTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantImportNameOnlyTest.php
@@ -9,7 +9,7 @@ use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextEdits;
 
-class TolerantImportNameTest extends AbstractTolerantImportNameTest
+class TolerantImportNameOnlyTest extends AbstractTolerantImportNameTest
 {
     public function provideImportClass(): Generator
     {
@@ -29,25 +29,25 @@ class TolerantImportNameTest extends AbstractTolerantImportNameTest
         ];
 
         yield 'with alias' => [
-            'importClass4.test',
+            'importOnlyClass4.test',
             'Barfoo\Foobar',
             'Barfoo',
         ];
 
         yield 'with static alias' => [
-            'importClass5.test',
+            'importOnlyClass5.test',
             'Barfoo\Foobar',
             'Barfoo',
         ];
 
         yield 'with multiple aliases' => [
-            'importClass6.test',
+            'importOnlyClass6.test',
             'Barfoo\Foobar',
             'Barfoo',
         ];
 
         yield 'with alias and existing name' => [
-            'importClass7.test',
+            'importOnlyClass7.test',
             'Barfoo\Foobar',
             'Barfoo',
         ];
@@ -79,6 +79,6 @@ class TolerantImportNameTest extends AbstractTolerantImportNameTest
     protected function importName($source, int $offset, NameImport $nameImport): TextEdits
     {
         $importClass = (new TolerantImportName($this->updater(), $this->parser()));
-        return $importClass->importName(SourceCode::fromString($source), ByteOffset::fromInt($offset), $nameImport);
+        return $importClass->importNameOnly(SourceCode::fromString($source), ByteOffset::fromInt($offset), $nameImport);
     }
 }

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass4.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass4.test
@@ -1,0 +1,10 @@
+// File: source
+<?php
+
+new F<>oobar();
+// File: expected
+<?php
+
+use Barfoo\Foobar as Barfoo;
+
+new Foobar();

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass5.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass5.test
@@ -1,0 +1,10 @@
+// File: source
+<?php
+
+F<>oobar::create();
+// File: expected
+<?php
+
+use Barfoo\Foobar as Barfoo;
+
+Foobar::create();

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass6.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass6.test
@@ -1,0 +1,18 @@
+// File: source
+<?php
+
+Zoo::create();
+
+function (Foobar $foobar) {
+    F<>oobar::create();
+}
+// File: expected
+<?php
+
+use Barfoo\Foobar as Barfoo;
+
+Zoo::create();
+
+function (Foobar $foobar) {
+    Foobar::create();
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass7.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/importOnlyClass7.test
@@ -1,0 +1,21 @@
+// File: source
+<?php
+
+use Zed\Foobar
+
+Zoo::create();
+
+function (Foobar $foobar) {
+    F<>oobar::create();
+}
+// File: expected
+<?php
+
+use Barfoo\Foobar as Barfoo;
+use Zed\Foobar
+
+Zoo::create();
+
+function (Foobar $foobar) {
+    Foobar::create();
+}


### PR DESCRIPTION
To not break anything I simply introduced another method `TolerantImportName::importNameOnly`.

Required for phpactor/phpactor#1248