### PR TITLE
Extract expression returns text edits

### DIFF
--- a/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -71,7 +71,9 @@ class TolerantExtractExpression implements ExtractExpression
                 $expressions = array_filter(
                     iterator_to_array($endNode->getDescendantNodes(), false),
                     function (Node $item) use ($endNode) {
-                        return $item instanceof Expression && $item->getEndPosition() == $endNode->expression->getEndPosition();
+                        return
+                            $item instanceof Expression &&
+                            $item->getEndPosition() == $endNode->expression->getEndPosition();
                     }
                 );
                 

--- a/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -2,13 +2,18 @@
 
 namespace Phpactor\CodeTransform\Adapter\TolerantParser\Refactor;
 
+use Microsoft\PhpParser\FunctionLike;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\StatementNode;
+use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\TextDocument\TextEdit;
 use Phpactor\TextDocument\TextEdits;
+use function end;
+use function iterator_to_array;
 
 class TolerantExtractExpression implements ExtractExpression
 {
@@ -22,82 +27,128 @@ class TolerantExtractExpression implements ExtractExpression
         $this->parser = $parser ?: new Parser();
     }
 
-    public function extractExpression(SourceCode $source, int $offsetStart, int $offsetEnd = null, string $variableName): TextEdits
+    public function canExtractExpression(SourceCode $source, int $offsetStart, ?int $offsetEnd = null): bool
     {
-        $rootNode = $this->parser->parseSourceFile((string) $source);
-        $startNode = $rootNode->getDescendantNodeAtPosition($offsetStart);
+        return $this->getExtractedExpression($source, $offsetStart, $offsetEnd) !== null;
+    }
 
-        $endPosition = $startNode->getEndPosition();
-        if ($offsetEnd) {
-            $endNode = $rootNode->getDescendantNodeAtPosition($offsetEnd);
-            $endPosition = $endNode->getEndPosition();
-        }
+    public function extractExpression(SourceCode $source, int $offsetStart, ?int $offsetEnd = null, string $variableName): TextEdits
+    {
+        $expression = $this->getExtractedExpression($source, $offsetStart, $offsetEnd);
+        if($expression === null)
+            return TextEdits::none();
 
-        $startNode = $this->outerNode($startNode);
-
-        $startPosition = $startNode->getStart();
-        $endPosition = $offsetEnd ?  : $startNode->getEndPosition();
+        $startPosition = $expression->getStart();
+        $endPosition = $expression->getEndPosition();
 
         $extractedString = rtrim(trim($source->extractSelection($startPosition, $endPosition)), ';');
         $assigment = sprintf('$%s = %s;', $variableName, $extractedString) . PHP_EOL;
 
-        if (!$startNode instanceof StatementNode) {
-            $statement = $startNode->getFirstAncestor(StatementNode::class);
-        } else {
-            $statement = $startNode;
-        }
-
-        if (null === $statement) {
-            return TextEdits::none();
-            // return $source;
-        }
-
+        $statement = $expression->getFirstAncestor(StatementNode::class);
         assert($statement instanceof StatementNode);
 
-        $edits = $this->resolveEdits($statement, $startNode, $extractedString, $assigment, $variableName);
+        $edits = $this->resolveEdits($statement, $expression, $extractedString, $assigment, $variableName);
 
         return TextEdits::fromTextEdits($edits);
-        // return $source->withSource(TextEdits::fromTextEdits($edits)->apply((string) $source));
     }
 
+    private function getExtractedExpression(SourceCode $source, int $offsetStart, ?int $offsetEnd): ?Expression
+    {
+        $rootNode = $this->parser->parseSourceFile((string) $source);
+        $startNode = $rootNode->getDescendantNodeAtPosition($offsetStart);
+
+        if ($offsetEnd) {
+            $endNode = $rootNode->getDescendantNodeAtPosition($offsetEnd);
+
+            $expression = $this->getCommonExpression($startNode, $endNode);
+            if($expression === null) {
+                // check if $endNode is not the whole row - try the last child
+                $children = iterator_to_array($endNode->getDescendantNodes());
+                $endNode = end($children);
+                if($endNode === false) {
+                    return null;
+                }
+                $expression = $this->getCommonExpression($startNode, $endNode);
+            }
+        } else {
+            $expression = $this->outerExpression($startNode);
+        }
+
+        if($expression === null) {
+            return null;
+        }
+        return $expression;
+    }
+    
+    private function getCommonExpression(Node $node1, Node $node2): ?Expression
+    {
+        if($node1 == $node2 && $node1 instanceof Expression)
+            return $node1;
+        $ancestor = $node1;
+        $expressions = [];
+        if($node1 instanceof Expression)
+            $expressions[] = $node1;
+
+        while (($ancestor = $ancestor->parent) !== null) {
+            if ($ancestor instanceof FunctionLike) {
+                break;
+            }
+            if($ancestor instanceof Expression === false) {
+                continue;
+            }
+            $expressions[] = $ancestor;
+        }
+
+        if(empty($expressions))
+            return null;
+
+        $ancestor = $node2;
+        while (($ancestor = $ancestor->parent) !== null) {
+            if(in_array($ancestor, $expressions, true)) {
+                return $ancestor;
+            }
+        }
+
+        return null;
+    }
     /**
      * @return array<TextEdit>
      */
     private function resolveEdits(
         Node $statement,
-        Node $startNode,
+        Node $expression,
         string $extractedString,
-        string $assigment,
+        string $assignment,
         string $variableName
     ): array {
-        if ($statement->getStart() === $startNode->getStart()) {
+        if ($statement->getStart() === $expression->getStart()) {
             return [
-                TextEdit::create($statement->getStart(), $statement->getWidth(), $assigment)
+                TextEdit::create($statement->getStart(), $statement->getWidth(), $assignment)
             ];
         }
 
         $indentation = mb_substr_count($statement->getLeadingCommentAndWhitespaceText(), ' ');
         
         return [
-            TextEdit::create($statement->getStart(), 0, $assigment . str_repeat(' ', $indentation)),
-            TextEdit::create($startNode->getStart(), strlen($extractedString), '$' . $variableName),
+            TextEdit::create($statement->getStart(), 0, $assignment . str_repeat(' ', $indentation)),
+            TextEdit::create($expression->getStart(), strlen($extractedString), '$' . $variableName),
         ];
     }
 
-    private function outerNode(Node $node, Node $originalNode = null): Node
+    private function outerExpression(Node $node, Node $originalNode = null): ?Expression
     {
         $originalNode = $originalNode ?: $node;
 
         $parent = $node->getParent();
 
         if (null === $parent) {
-            return $node;
+            return $node instanceof Expression ? $node : null;
         }
 
-        if ($parent->getStart() !== $originalNode->getStart()) {
+        if ($parent->getStart() !== $originalNode->getStart() && $originalNode instanceof Expression) {
             return $originalNode;
         }
 
-        return $this->outerNode($parent, $originalNode);
+        return $this->outerExpression($parent, $originalNode);
     }
 }

--- a/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -14,6 +14,7 @@ use Phpactor\TextDocument\TextEdit;
 use Phpactor\TextDocument\TextEdits;
 use function end;
 use function iterator_to_array;
+use function preg_match;
 
 class TolerantExtractExpression implements ExtractExpression
 {
@@ -144,13 +145,14 @@ class TolerantExtractExpression implements ExtractExpression
             ];
         }
 
-        $leadingWhitespace = $statement->getLeadingCommentAndWhitespaceText();
-        $leadingSpaces = mb_substr_count($leadingWhitespace, ' ');
-        $leadingTabs = mb_substr_count($leadingWhitespace, "\t");
-        $indentation = max($leadingSpaces, $leadingTabs);
+        $matches = [];
+        $indentation = '';
+        if (preg_match('/(\t| )*$/', $statement->getLeadingCommentAndWhitespaceText(), $matches) > 0) {
+            $indentation = $matches[0];
+        }
         
         return [
-            TextEdit::create($statement->getStart(), 0, $assignment . str_repeat($leadingSpaces > $leadingTabs ? ' ' : "\t", $indentation)),
+            TextEdit::create($statement->getStart(), 0, $assignment . $indentation),
             TextEdit::create($expression->getStart(), strlen($extractedString), '$' . $variableName),
         ];
     }

--- a/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -6,7 +6,6 @@ use Microsoft\PhpParser\FunctionLike;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\StatementNode;
-use Microsoft\PhpParser\Node\Statement\ExpressionStatement;
 use Microsoft\PhpParser\Parser;
 use Phpactor\CodeTransform\Domain\Refactor\ExtractExpression;
 use Phpactor\CodeTransform\Domain\SourceCode;
@@ -35,8 +34,9 @@ class TolerantExtractExpression implements ExtractExpression
     public function extractExpression(SourceCode $source, int $offsetStart, ?int $offsetEnd = null, string $variableName): TextEdits
     {
         $expression = $this->getExtractedExpression($source, $offsetStart, $offsetEnd);
-        if($expression === null)
+        if ($expression === null) {
             return TextEdits::none();
+        }
 
         $startPosition = $expression->getStart();
         $endPosition = $expression->getEndPosition();
@@ -61,11 +61,11 @@ class TolerantExtractExpression implements ExtractExpression
             $endNode = $rootNode->getDescendantNodeAtPosition($offsetEnd);
 
             $expression = $this->getCommonExpression($startNode, $endNode);
-            if($expression === null) {
+            if ($expression === null) {
                 // check if $endNode is not the whole row - try the last child
                 $children = iterator_to_array($endNode->getDescendantNodes());
                 $endNode = end($children);
-                if($endNode === false) {
+                if ($endNode === false) {
                     return null;
                 }
                 $expression = $this->getCommonExpression($startNode, $endNode);
@@ -74,7 +74,7 @@ class TolerantExtractExpression implements ExtractExpression
             $expression = $this->outerExpression($startNode);
         }
 
-        if($expression === null) {
+        if ($expression === null) {
             return null;
         }
         return $expression;
@@ -82,29 +82,32 @@ class TolerantExtractExpression implements ExtractExpression
     
     private function getCommonExpression(Node $node1, Node $node2): ?Expression
     {
-        if($node1 == $node2 && $node1 instanceof Expression)
+        if ($node1 == $node2 && $node1 instanceof Expression) {
             return $node1;
+        }
         $ancestor = $node1;
         $expressions = [];
-        if($node1 instanceof Expression)
+        if ($node1 instanceof Expression) {
             $expressions[] = $node1;
+        }
 
         while (($ancestor = $ancestor->parent) !== null) {
             if ($ancestor instanceof FunctionLike) {
                 break;
             }
-            if($ancestor instanceof Expression === false) {
+            if ($ancestor instanceof Expression === false) {
                 continue;
             }
             $expressions[] = $ancestor;
         }
 
-        if(empty($expressions))
+        if (empty($expressions)) {
             return null;
+        }
 
         $ancestor = $node2;
         while (($ancestor = $ancestor->parent) !== null) {
-            if(in_array($ancestor, $expressions, true)) {
+            if (in_array($ancestor, $expressions, true)) {
                 return $ancestor;
             }
         }

--- a/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantExtractExpression.php
@@ -22,7 +22,7 @@ class TolerantExtractExpression implements ExtractExpression
         $this->parser = $parser ?: new Parser();
     }
 
-    public function extractExpression(SourceCode $source, int $offsetStart, int $offsetEnd = null, string $variableName): SourceCode
+    public function extractExpression(SourceCode $source, int $offsetStart, int $offsetEnd = null, string $variableName): TextEdits
     {
         $rootNode = $this->parser->parseSourceFile((string) $source);
         $startNode = $rootNode->getDescendantNodeAtPosition($offsetStart);
@@ -48,14 +48,16 @@ class TolerantExtractExpression implements ExtractExpression
         }
 
         if (null === $statement) {
-            return $source;
+            return TextEdits::none();
+            // return $source;
         }
 
         assert($statement instanceof StatementNode);
 
         $edits = $this->resolveEdits($statement, $startNode, $extractedString, $assigment, $variableName);
 
-        return $source->withSource(TextEdits::fromTextEdits($edits)->apply((string) $source));
+        return TextEdits::fromTextEdits($edits);
+        // return $source->withSource(TextEdits::fromTextEdits($edits)->apply((string) $source));
     }
 
     /**

--- a/lib/Domain/Refactor/ExtractExpression.php
+++ b/lib/Domain/Refactor/ExtractExpression.php
@@ -3,8 +3,9 @@
 namespace Phpactor\CodeTransform\Domain\Refactor;
 
 use Phpactor\CodeTransform\Domain\SourceCode;
+use Phpactor\TextDocument\TextEdits;
 
 interface ExtractExpression
 {
-    public function extractExpression(SourceCode $source, int $offsetStart, int $offsetEnd = null, string $variableName): SourceCode;
+    public function extractExpression(SourceCode $source, int $offsetStart, int $offsetEnd = null, string $variableName): TextEdits;
 }

--- a/lib/Domain/Refactor/ExtractExpression.php
+++ b/lib/Domain/Refactor/ExtractExpression.php
@@ -7,5 +7,6 @@ use Phpactor\TextDocument\TextEdits;
 
 interface ExtractExpression
 {
+    public function canExtractExpression(SourceCode $source, int $offsetStart, ?int $offsetEnd = null): bool;
     public function extractExpression(SourceCode $source, int $offsetStart, int $offsetEnd = null, string $variableName): TextEdits;
 }

--- a/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
@@ -41,7 +41,7 @@ class TolerantExtractExpressionTest extends TolerantTestCase
             'foobar',
         ];
 
-        yield 'extract on end position semi-colon' => [
+        yield 'extract on end position semi-colon: object creation' => [
             'extractExpression3.test',
             'foobar',
         ];
@@ -56,8 +56,13 @@ class TolerantExtractExpressionTest extends TolerantTestCase
             'foobar',
         ];
 
-        yield 'single stand-alone array expression' => [
+        yield 'stand-alone expression: whole expression' => [
             'extractExpression6.test',
+            'foobar',
+        ];
+
+        yield 'stand-alone expression: partial expression' => [
+            'extractExpression6A.test',
             'foobar',
         ];
 
@@ -68,6 +73,11 @@ class TolerantExtractExpressionTest extends TolerantTestCase
 
         yield 'preserve statement indentation' => [
             'extractExpression8.test',
+            'foobar',
+        ];
+
+        yield 'preserve statement indentation with tabs' => [
+            'extractExpression8A.test',
             'foobar',
         ];
 
@@ -108,6 +118,16 @@ class TolerantExtractExpressionTest extends TolerantTestCase
 
         yield 'should not: on function declaration' => [
             'extractExpression16.test',
+            'foobar',
+        ];
+
+        yield 'single assignment expression: method call without semi-colon' => [
+            'extractExpression17.test',
+            'foobar',
+        ];
+
+        yield 'single assignment expression: method call with semi-colon' => [
+            'extractExpression17A.test',
             'foobar',
         ];
     }

--- a/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
@@ -22,8 +22,9 @@ class TolerantExtractExpressionTest extends TolerantTestCase
         }
 
         $extractMethod = new TolerantExtractExpression();
-        $transformed = $extractMethod->extractExpression(SourceCode::fromString($source), $offsetStart, $offsetEnd, $name);
-
+        
+        $textEdits = $extractMethod->extractExpression(SourceCode::fromString($source), $offsetStart, $offsetEnd, $name);
+        $transformed = $textEdits->apply($source);
         $this->assertEquals(trim($expected), trim($transformed));
     }
 

--- a/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
@@ -71,13 +71,18 @@ class TolerantExtractExpressionTest extends TolerantTestCase
             'foobar',
         ];
 
-        yield 'preserve statement indentation' => [
+        yield 'preserve statement indentation: spaces' => [
             'extractExpression8.test',
             'foobar',
         ];
 
-        yield 'preserve statement indentation with tabs' => [
+        yield 'preserve statement indentation: tabs' => [
             'extractExpression8A.test',
+            'foobar',
+        ];
+ 
+        yield 'preserve statement indentation: tabs and comments' => [
+            'extractExpression8B.test',
             'foobar',
         ];
 

--- a/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
@@ -3,6 +3,7 @@
 namespace Phpactor\CodeTransform\Tests\Adapter\TolerantParser\Refactor;
 
 use Exception;
+use Generator;
 use Phpactor\CodeTransform\Adapter\TolerantParser\Refactor\TolerantExtractExpression;
 use Phpactor\CodeTransform\Domain\SourceCode;
 use Phpactor\CodeTransform\Tests\Adapter\TolerantParser\TolerantTestCase;
@@ -28,7 +29,7 @@ class TolerantExtractExpressionTest extends TolerantTestCase
         $this->assertEquals(trim($expected), trim($transformed));
     }
 
-    public function provideExtractExpression()
+    public function provideExtractExpression(): Generator
     {
         yield 'no op' => [
             'extractExpression1.test',
@@ -72,6 +73,41 @@ class TolerantExtractExpressionTest extends TolerantTestCase
 
         yield 'extract element in array' => [
             'extractExpression9.test',
+            'foobar',
+        ];
+
+        yield 'should not: start on method definition' => [
+            'extractExpression10.test',
+            'foobar',
+        ];
+
+        yield 'should not: start and end in different methods' => [
+            'extractExpression11.test',
+            'foobar',
+        ];
+
+        yield 'should not: start and end in different expressions' => [
+            'extractExpression12.test',
+            'foobar',
+        ];
+
+        yield 'multiline expression' => [
+            'extractExpression13.test',
+            'foobar',
+        ];
+
+        yield 'should not: inside class member list' => [
+            'extractExpression14.test',
+            'foobar',
+        ];
+
+        yield 'should not: class declaration' => [
+            'extractExpression15.test',
+            'foobar',
+        ];
+
+        yield 'should not: on function declaration' => [
+            'extractExpression16.test',
             'foobar',
         ];
     }

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression10.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression10.test
@@ -1,0 +1,22 @@
+// File: source
+<?php
+
+class Foobar
+{
+    public function hel<>lo()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+}
+// File: expected
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression11.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression11.test
@@ -1,0 +1,32 @@
+// File: source
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        if ('he<>llo' . $bar === null) {
+        }
+    }
+
+    public function bye()
+    {
+        <>
+    }
+}
+// File: expected
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+
+    public function bye()
+    {
+        
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression12.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression12.test
@@ -1,0 +1,22 @@
+// File: source
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        $bar = 'y<>es';
+        $bar = 'hel<>lo' . $bar;
+    }
+}
+// File: expected
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        $bar = 'yes';
+        $bar = 'hello' . $bar;
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression13.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression13.test
@@ -1,0 +1,29 @@
+// File: source
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        $bar = 
+            ($fo<>o ? 
+                '1' : 
+                '2'<>). 
+            ' times';
+    }
+}
+// File: expected
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        $foobar = $foo ? 
+                '1' : 
+                '2';
+        $bar = 
+            ($foobar). 
+            ' times';
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression14.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression14.test
@@ -1,0 +1,24 @@
+// File: source
+<?php
+
+class Foobar
+{
+    <>
+    public function hello()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+}
+// File: expected
+<?php
+
+class Foobar
+{
+    
+    public function hello()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression15.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression15.test
@@ -1,0 +1,22 @@
+// File: source
+<?php
+
+clas<>s Foobar
+{
+    public function hello()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+}
+// File: expected
+<?php
+
+class Foobar
+{
+    public function hello()
+    {
+        if ('hello' . $bar === null) {
+        }
+    }
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression16.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression16.test
@@ -1,0 +1,12 @@
+// File: source
+<?php
+
+function f<>(){
+
+}
+// File: expected
+<?php
+
+function f(){
+
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression17.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression17.test
@@ -1,0 +1,12 @@
+// File: source
+<?php
+
+function f<>(){
+
+}
+// File: expected
+<?php
+
+function f(){
+
+}

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression17.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression17.test
@@ -1,12 +1,21 @@
 // File: source
 <?php
 
-function f<>(){
-
+class Class2
+{
+    public function method()
+    {
+        <>$someclass->someMethod()<>;
+    }
 }
 // File: expected
 <?php
 
-function f(){
+class Class2
+{
+    public function method()
+    {
+        $foobar = $someclass->someMethod();
 
+    }
 }

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression17A.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression17A.test
@@ -1,0 +1,8 @@
+// File: source
+<?php
+
+<>$obj->method();<>
+// File: expected
+<?php
+
+$foobar = $obj->method();

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression6A.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression6A.test
@@ -1,0 +1,9 @@
+// File: source
+<?php
+
+<>$obj<>->method();
+// File: expected
+<?php
+
+$foobar = $obj;
+$foobar->method();

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression8A.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression8A.test
@@ -1,0 +1,24 @@
+// File: source
+<?php
+
+class Foobar
+{
+	public function hello()
+	{
+		if ('h<>ello' . $bar<> === null) {
+		}
+	}
+}
+// File: expected
+<?php
+
+class Foobar
+{
+	public function hello()
+	{
+		$foobar = 'hello' . $bar;
+		if ($foobar === null) {
+		}
+	}
+}
+

--- a/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression8B.test
+++ b/tests/Adapter/TolerantParser/Refactor/fixtures/extractExpression8B.test
@@ -1,0 +1,26 @@
+// File: source
+<?php
+
+class Foobar
+{
+	public function hello()
+	{
+		// some comment
+		if ('h<>ello' . $bar<> === null) {
+		}
+	}
+}
+// File: expected
+<?php
+
+class Foobar
+{
+	public function hello()
+	{
+		// some comment
+		$foobar = 'hello' . $bar;
+		if ($foobar === null) {
+		}
+	}
+}
+


### PR DESCRIPTION
I also reworked the code a bit:

* I put some validation in - we want only `Expression`s to be able to be extracted
* If both start and end are selected, we want them to be on the same `Expression` (have it as a common parent).
* Added more tests to test to first two points
* Added `canExtractExpression`