### PR TITLE
Prevent resolving of unresolvable names multiple times.

### DIFF
--- a/lib/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinder.php
+++ b/lib/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinder.php
@@ -122,6 +122,12 @@ class WorseUnresolvableClassNameFinder implements UnresolvableClassNameFinder
 
     private function appendUnresolvedClassName(string $nameText, array $unresolvedNames, QualifiedName $name): array
     {
+        if (current(array_filter($unresolvedNames, function (NameWithByteOffset $name) use ($nameText) {
+            return (string)$name->name() === $nameText;
+        })) !== false) {
+            return $unresolvedNames;
+        }
+        
         try {
             $class = $this->reflector->sourceCodeForClassLike($nameText);
         } catch (NotFound $notFound) {
@@ -137,6 +143,12 @@ class WorseUnresolvableClassNameFinder implements UnresolvableClassNameFinder
 
     private function appendUnresolvedFunctionName(string $nameText, array $unresolvedNames, QualifiedName $name): array
     {
+        if (current(array_filter($unresolvedNames, function (NameWithByteOffset $name) use ($nameText) {
+            return (string)$name->name() === $nameText;
+        })) !== false) {
+            return $unresolvedNames;
+        }
+
         try {
             $this->reflector->sourceCodeForFunction($nameText);
         } catch (NotFound $notFound) {

--- a/tests/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinderTest.php
+++ b/tests/Adapter/WorseReflection/Helper/WorseUnresolvableClassNameFinderTest.php
@@ -79,7 +79,7 @@ class WorseUnresolvableClassNameFinderTest extends WorseTestCase
         yield 'unresolvable class' => [
             <<<'EOT'
                 // File: test.php
-                <?php new NotFound();
+                <?php new NotFound(); new NotFound();
                 EOT
             ,[
                 new NameWithByteOffset(
@@ -345,7 +345,7 @@ class WorseUnresolvableClassNameFinderTest extends WorseTestCase
         yield 'unresolvable function' => [
             <<<'EOT'
                 // File: test.php
-                <?php foo();
+                <?php foo(); foo();
                 EOT
             ,[
                 new NameWithByteOffset(


### PR DESCRIPTION
This surely was slowing down the import names menu. If a single name appears in code multiple times, it is resolved multiple times and then returned multiple times and shown the same number of times.

The only thing I am unsure of is how at some point the names are deduped by somebody... There is probably another case in there somewhere.

Fixes https://github.com/phpactor/phpactor/issues/1253.