### PR TITLE
Import: Report back name and FQN if exist; stricter finding

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         '@PSR2' => true,
         'no_unused_imports' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'list_syntax' => ['syntax' => 'short'],
         'void_return' => true,
         'ordered_class_elements' => true,
         'single_quote' => true,
@@ -22,4 +23,3 @@ return PhpCsFixer\Config::create()
     ])
     ->setFinder($finder)
 ;
-

--- a/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -77,11 +77,15 @@ class TolerantImportName implements ImportName
         $imports = $node->getImportTablesForCurrentScope()[$this->resolveImportTableOffset($nameImport)];
 
         if (null === $nameImport->alias() && isset($imports[$nameImport->name()->head()->__toString()])) {
-            throw new NameAlreadyImportedException($nameImport, $this->findExistingName($nameImport, $imports));
+            throw new NameAlreadyImportedException(
+                $nameImport,
+                $this->findExistingName($nameImport, $imports),
+                $nameImport->name()
+            );
         }
 
         if (null === $nameImport->alias() && $currentClass && $currentClass->short() === $nameImport->name()->head()->__toString()) {
-            throw new NameAlreadyImportedException($nameImport, $currentClass->__toString());
+            throw new NameAlreadyImportedException($nameImport, $currentClass->short(), $currentClass->__toString());
         }
 
         if ($nameImport->alias() && isset($imports[$nameImport->alias()])) {
@@ -113,19 +117,19 @@ class TolerantImportName implements ImportName
     /**
      * @param NameImport $nameImport
      * @param array<ResolvedName> $imports
-     * @return ResolvedName
+     * @return string
      */
-    private function findExistingName(NameImport $nameImport, array $imports): ResolvedName
+    private function findExistingName(NameImport $nameImport, array $imports): string
     {
         $nameImportParts = $nameImport->name()->toArray();
 
-        foreach ($imports as $import) {
+        foreach ($imports as $importName => $import) {
             if ($import->getNameParts() === $nameImportParts) {
-                return $import;
+                return $importName;
             }
         }
 
-        return $imports[$nameImport->name()->head()->__toString()];
+        return $nameImport->name()->head()->__toString();
     }
 
     private function addImport(SourceCode $source, NameImport $nameImport): TextEdits

--- a/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
+++ b/lib/Adapter/TolerantParser/Refactor/TolerantImportName.php
@@ -18,7 +18,6 @@ use Phpactor\CodeBuilder\Domain\Builder\SourceCodeBuilder;
 use Microsoft\PhpParser\Node;
 use Phpactor\CodeBuilder\Domain\Code;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\AliasAlreadyUsedException;
-use Microsoft\PhpParser\Node\Statement\ClassDeclaration;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\ClassIsCurrentClassException;
 use Phpactor\CodeTransform\Domain\Refactor\ImportClass\NameAlreadyInNamespaceException;
 use Phpactor\Name\FullyQualifiedName;
@@ -129,7 +128,7 @@ class TolerantImportName implements ImportName
 
     private function currentClassIsSameAsImportClass(Node $node, FullyQualifiedName $className): bool
     {
-        if (!$node instanceof ClassDeclaration) {
+        if (!$node instanceof ClassLike || !$node instanceof NamespacedNameInterface) {
             return false;
         }
 

--- a/lib/Domain/Refactor/ImportClass/NameAlreadyImportedException.php
+++ b/lib/Domain/Refactor/ImportClass/NameAlreadyImportedException.php
@@ -14,7 +14,12 @@ class NameAlreadyImportedException extends NameAlreadyUsedException
      */
     private $existingName;
 
-    public function __construct(NameImport $nameImport, string $existingName)
+    /**
+     * @var string
+     */
+    private $existingFQN;
+
+    public function __construct(NameImport $nameImport, string $existingName, string $existingFQN)
     {
         parent::__construct(sprintf(
             '%s "%s" is already imported',
@@ -24,6 +29,7 @@ class NameAlreadyImportedException extends NameAlreadyUsedException
 
         $this->name = $nameImport->name()->head()->__toString();
         $this->existingName = $existingName;
+        $this->existingFQN = $existingFQN;
     }
 
     public function name(): string
@@ -34,5 +40,10 @@ class NameAlreadyImportedException extends NameAlreadyUsedException
     public function existingName(): string
     {
         return $this->existingName;
+    }
+
+    public function existingFQN(): string
+    {
+        return $this->existingFQN;
     }
 }

--- a/tests/Adapter/AdapterTestCase.php
+++ b/tests/Adapter/AdapterTestCase.php
@@ -43,8 +43,8 @@ class AdapterTestCase extends TestCase
 
     protected function sourceExpectedAndOffset($manifestPath)
     {
-        list($source, $expected) = $this->sourceExpected($manifestPath);
-        list($source, $offsetStart, $offsetEnd) = ExtractOffset::fromSource($source);
+        [$source, $expected] = $this->sourceExpected($manifestPath);
+        [$source, $offsetStart, $offsetEnd] = ExtractOffset::fromSource($source);
 
         return [ $source, $expected, $offsetStart, $offsetEnd ];
     }

--- a/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -48,7 +48,7 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
         $this->importNameFromTestFile('class', 'importClass1.test', 'Foobar', 'DateTime');
     }
 
-    public function testThrowsNameAlreadyImportedExistingName(): void
+    public function testThrowsNameAlreadyImportedExistingAliasName(): void
     {
         try {
             $this->importName(
@@ -62,6 +62,57 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
             self::assertSame('Bar', $error->name());
             self::assertSame('Foo2Bar', $error->existingName());
             self::assertSame('Foo2\Bar', $error->existingFQN());
+        }
+    }
+
+    public function testThrowsNameAlreadyImportedOnlyAliasName(): void
+    {
+        try {
+            $this->importName(
+                '<?php namespace Foo; use Foo2\Bar as Foo2Bar;',
+                45,
+                NameImport::forClass('Foo2\Bar')
+            );
+            self::fail('Expected NameAlreadyImportedException has not been raised');
+        } catch (NameAlreadyImportedException $error) {
+            self::assertSame('Class "Bar" is already imported', $error->getMessage());
+            self::assertSame('Bar', $error->name());
+            self::assertSame('Foo2Bar', $error->existingName());
+            self::assertSame('Foo2\Bar', $error->existingFQN());
+        }
+    }
+
+    public function testThrowsNameAlreadyImportedFunction(): void
+    {
+        try {
+            $this->importName(
+                '<?php use function in_array;',
+                55,
+                NameImport::forFunction('in_array')
+            );
+            self::fail('Expected NameAlreadyImportedException has not been raised');
+        } catch (NameAlreadyImportedException $error) {
+            self::assertSame('Function "in_array" is already imported', $error->getMessage());
+            self::assertSame('in_array', $error->name());
+            self::assertSame('in_array', $error->existingName());
+            self::assertSame('in_array', $error->existingFQN());
+        }
+    }
+
+    public function testThrowsNameAlreadyImportedFunctionAlias(): void
+    {
+        try {
+            $this->importName(
+                '<?php use function in_array as foo_in_array;',
+                55,
+                NameImport::forFunction('in_array')
+            );
+            self::fail('Expected NameAlreadyImportedException has not been raised');
+        } catch (NameAlreadyImportedException $error) {
+            self::assertSame('Function "in_array" is already imported', $error->getMessage());
+            self::assertSame('in_array', $error->name());
+            self::assertSame('foo_in_array', $error->existingName());
+            self::assertSame('in_array', $error->existingFQN());
         }
     }
 

--- a/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -65,6 +65,23 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
         }
     }
 
+    public function testThrowsNameAlreadyImportedNameInUse(): void
+    {
+        try {
+            $this->importName(
+                '<?php namespace Foo; use Foo1\Bar;',
+                34,
+                NameImport::forClass('Foo2\Bar')
+            );
+            self::fail('Expected NameAlreadyImportedException has not been raised');
+        } catch (NameAlreadyImportedException $error) {
+            self::assertSame('Class "Bar" is already imported', $error->getMessage());
+            self::assertSame('Bar', $error->name());
+            self::assertSame('Bar', $error->existingName());
+            self::assertSame('Foo1\Bar', $error->existingFQN());
+        }
+    }
+
     public function testThrowsNameAlreadyImportedOnlyAliasName(): void
     {
         try {

--- a/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -59,18 +59,27 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
             self::fail('Expected NameAlreadyImportedException has not been raised');
         } catch (NameAlreadyImportedException $error) {
             self::assertSame('Class "Bar" is already imported', $error->getMessage());
-            self::assertSame('Foo2\Bar', $error->existingName());
+            self::assertSame('Bar', $error->name());
+            self::assertSame('Foo2Bar', $error->existingName());
+            self::assertSame('Foo2\Bar', $error->existingFQN());
         }
     }
 
     public function testThrowsExceptionIfImportedClassHasSameNameAsCurrentClassName(): void
     {
-        $this->expectException(NameAlreadyImportedException::class);
-        $this->importName(
-            '<?php namespace Barfoo; class Foobar extends Foobar',
-            47,
-            NameImport::forClass('BazBar\Foobar')
-        );
+        try {
+            $this->importName(
+                '<?php namespace Barfoo; class Foobar extends Foobar',
+                47,
+                NameImport::forClass('BazBar\Foobar')
+            );
+            self::fail('Expected NameAlreadyImportedException has not been raised');
+        } catch (NameAlreadyImportedException $error) {
+            self::assertSame('Class "Foobar" is already imported', $error->getMessage());
+            self::assertSame('Foobar', $error->name());
+            self::assertSame('Foobar', $error->existingName());
+            self::assertSame('Barfoo\Foobar', $error->existingFQN());
+        }
     }
 
     public function testThrowsExceptionIfImportedClassHasSameNameAsCurrentInterfaceName(): void

--- a/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -20,7 +20,7 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
      */
     public function testImportClass(string $test, string $name, string $alias = null): void
     {
-        list($expected, $transformed) = $this->importNameFromTestFile('class', $test, $name, $alias);
+        [$expected, $transformed] = $this->importNameFromTestFile('class', $test, $name, $alias);
 
         $this->assertEquals(trim($expected), trim($transformed));
     }
@@ -195,7 +195,7 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
      */
     public function testImportFunction(string $test, string $name, string $alias = null): void
     {
-        list($expected, $transformed) = $this->importNameFromTestFile('function', $test, $name, $alias);
+        [$expected, $transformed] = $this->importNameFromTestFile('function', $test, $name, $alias);
 
         $this->assertEquals(trim($expected), trim($transformed));
     }
@@ -206,7 +206,7 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
 
     private function importNameFromTestFile(string $type, string $test, string $name, string $alias = null)
     {
-        list($source, $expected, $offset) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
         $edits = TextEdits::none();
 
         if ($type === 'class') {

--- a/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/AbstractTolerantImportNameTest.php
@@ -41,6 +41,20 @@ abstract class AbstractTolerantImportNameTest extends TolerantTestCase
         $this->importName('<?php class Foobar {}', 14, NameImport::forClass('Foobar'));
     }
 
+    public function testThrowsExceptionClassIsCurrentClassExceptionTrait(): void
+    {
+        $this->expectException(ClassIsCurrentClassException::class);
+        $this->expectExceptionMessage('Class "Foobar" is the current class');
+        $this->importName('<?php trait Foobar {}', 14, NameImport::forClass('Foobar'));
+    }
+
+    public function testThrowsExceptionClassIsCurrentClassExceptionInterface(): void
+    {
+        $this->expectException(ClassIsCurrentClassException::class);
+        $this->expectExceptionMessage('Class "Foobar" is the current class');
+        $this->importName('<?php interface Foobar {}', 14, NameImport::forClass('Foobar'));
+    }
+
     public function testThrowsExceptionIfAliasAlreadyUsed(): void
     {
         $this->expectException(AliasAlreadyUsedException::class);

--- a/tests/Adapter/TolerantParser/Refactor/TolerantChangeVisiblityTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantChangeVisiblityTest.php
@@ -13,7 +13,7 @@ class TolerantChangeVisiblityTest extends TolerantTestCase
      */
     public function testExtractExpression(string $test): void
     {
-        list($source, $expected, $offsetStart) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offsetStart] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
         $extractMethod = new TolerantChangeVisiblity();
         $transformed = $extractMethod->changeVisiblity(SourceCode::fromString($source), $offsetStart);

--- a/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantExtractExpressionTest.php
@@ -15,7 +15,7 @@ class TolerantExtractExpressionTest extends TolerantTestCase
      */
     public function testExtractExpression(string $test, string $name, string $expectedExceptionMessage = null): void
     {
-        list($source, $expected, $offsetStart, $offsetEnd) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offsetStart, $offsetEnd] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
         if ($expectedExceptionMessage) {
             $this->expectException(Exception::class);

--- a/tests/Adapter/TolerantParser/Refactor/TolerantRenameVariableTest.php
+++ b/tests/Adapter/TolerantParser/Refactor/TolerantRenameVariableTest.php
@@ -14,7 +14,7 @@ class TolerantRenameVariableTest extends TolerantTestCase
      */
     public function testRenameVariable(string $test, $name, string $scope = RenameVariable::SCOPE_FILE): void
     {
-        list($source, $expected, $offset) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
         $renameVariable = new TolerantRenameVariable($this->parser());
         $transformed = $renameVariable->renameVariable(SourceCode::fromString($source), $offset, $name, $scope);

--- a/tests/Adapter/WorseReflection/Refactor/WorseExtractConstantTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseExtractConstantTest.php
@@ -14,7 +14,7 @@ class WorseExtractConstantTest extends WorseTestCase
      */
     public function testExtractConstant(string $test, $name): void
     {
-        list($source, $expected, $offset) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
         $extractConstant = new WorseExtractConstant($this->reflectorForWorkspace($source), $this->updater());
         $transformed = $extractConstant->extractConstant(SourceCode::fromString($source), $offset, $name);

--- a/tests/Adapter/WorseReflection/Refactor/WorseExtractMethodTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseExtractMethodTest.php
@@ -16,7 +16,7 @@ class WorseExtractMethodTest extends WorseTestCase
      */
     public function testExtractMethod(string $test, ?string $name, ?string $expectedExceptionMessage = null): void
     {
-        list($source, $expected, $offsetStart, $offsetEnd) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offsetStart, $offsetEnd] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
         if ($expectedExceptionMessage) {
             $this->expectException(Exception::class);

--- a/tests/Adapter/WorseReflection/Refactor/WorseGenerateAccessorTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseGenerateAccessorTest.php
@@ -18,7 +18,7 @@ class WorseGenerateAccessorTest extends WorseTestCase
         string $prefix = '',
         ?bool $upperCaseFirst = null
     ): void {
-        list($source, $expected, $offset) = $this->sourceExpectedAndOffset(
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset(
             __DIR__ . '/fixtures/' . $test
         );
 

--- a/tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseGenerateMethodTest.php
@@ -16,7 +16,7 @@ class WorseGenerateMethodTest extends WorseTestCase
      */
     public function testGenerateMethod(string $test, ?string $name = null): void
     {
-        list($source, $expected, $offset) = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected, $offset] = $this->sourceExpectedAndOffset(__DIR__ . '/fixtures/' . $test);
 
         $transformed = $this->generateMethod($source, $offset, $name);
 

--- a/tests/Adapter/WorseReflection/Refactor/WorseOverrideMethodTest.php
+++ b/tests/Adapter/WorseReflection/Refactor/WorseOverrideMethodTest.php
@@ -15,7 +15,7 @@ class WorseOverrideMethodTest extends WorseTestCase
      */
     public function testOverrideMethod(string $test, string $className, $methodName): void
     {
-        list($source, $expected) = $this->sourceExpected(__DIR__ . '/fixtures/' . $test);
+        [$source, $expected] = $this->sourceExpected(__DIR__ . '/fixtures/' . $test);
 
         $transformed = $this->overrideMethod($source, $className, $methodName);
 


### PR DESCRIPTION
More changes to this 🙈

**Existing name and FQN if already exists**

I found out that knowing the FQN is not enough. If it is already imported the existing name should be the imported existing name (as before). Additionally I have added the FQN.

**Stricter existing import search**

The first attempt is now looking for the FQN. After that it tries to locate the short name.